### PR TITLE
Fix ADLS source to remove getSchema functionality

### DIFF
--- a/adls-plugins/widgets/AzureDataLakeStore-batchsource.json
+++ b/adls-plugins/widgets/AzureDataLakeStore-batchsource.json
@@ -59,66 +59,60 @@
             ],
             "default": "false"
           }
+        }
+      ]
+    },
+    {
+      "label": "Output Schema Properties",
+      "properties": [
+        {
+          "widget-type": "textbox",
+          "label": "Path Field",
+          "name": "pathField"
         },
         {
-          "label": "Output Schema Properties",
-          "properties": [
-            {
-              "widget-type": "textbox",
-              "label": "Path Field",
-              "name": "pathField",
-              "plugin-function": {
-                "method": "POST",
-                "widget": "outputSchema",
-                "output-property": "schema",
-                "plugin-method": "getSchema"
-              }
-            },
-            {
-              "widget-type": "select",
-              "label": "Use File Name as Path Field",
-              "name": "filenameOnly",
-              "widget-attributes": {
-                "values": [
-                  "true",
-                  "false"
-                ],
-                "default": "false"
-              }
-            }
-          ]
+          "widget-type": "select",
+          "label": "Use File Name as Path Field",
+          "name": "filenameOnly",
+          "widget-attributes": {
+            "values": [
+              "true",
+              "false"
+            ],
+            "default": "false"
+          }
+        }
+      ]
+    },
+    {
+      "label": "Advanced Properties",
+      "properties": [
+        {
+          "widget-type": "textbox",
+          "label": "Input Format Class",
+          "name": "inputFormatClass"
         },
         {
-          "label": "Advanced Properties",
-          "properties": [
-            {
-              "widget-type": "textbox",
-              "label": "Input Format Class",
-              "name": "inputFormatClass"
-            },
-            {
-              "widget-type": "json-editor",
-              "label": "File System Properties",
-              "name": "fileSystemProperties"
-            },
-            {
-              "widget-type": "select",
-              "label": "Ignore Non-Existing Folders",
-              "name": "ignoreNonExistingFolders",
-              "widget-attributes": {
-                "values": [
-                  "true",
-                  "false"
-                ],
-                "default": "false"
-              }
-            },
-            {
-              "widget-type": "textbox",
-              "label": "Time Table",
-              "name": "timeTable"
-            }
-          ]
+          "widget-type": "json-editor",
+          "label": "File System Properties",
+          "name": "fileSystemProperties"
+        },
+        {
+          "widget-type": "select",
+          "label": "Ignore Non-Existing Folders",
+          "name": "ignoreNonExistingFolders",
+          "widget-attributes": {
+            "values": [
+              "true",
+              "false"
+            ],
+            "default": "false"
+          }
+        },
+        {
+          "widget-type": "textbox",
+          "label": "Time Table",
+          "name": "timeTable"
         }
       ]
     }

--- a/filesource-common/src/main/java/io/cdap/plugin/common/AbstractFileBatchSource.java
+++ b/filesource-common/src/main/java/io/cdap/plugin/common/AbstractFileBatchSource.java
@@ -23,7 +23,6 @@ import io.cdap.cdap.api.data.schema.Schema;
 import io.cdap.cdap.api.dataset.DatasetProperties;
 import io.cdap.cdap.api.dataset.lib.KeyValue;
 import io.cdap.cdap.api.dataset.lib.KeyValueTable;
-import io.cdap.cdap.api.plugin.EndpointPluginContext;
 import io.cdap.cdap.etl.api.Emitter;
 import io.cdap.cdap.etl.api.PipelineConfigurer;
 import io.cdap.cdap.etl.api.batch.BatchSourceContext;
@@ -207,17 +206,5 @@ public abstract class AbstractFileBatchSource<T extends FileSourceConfig>
     } catch (IOException e) {
       throw new IllegalArgumentException(String.format("Error deleting temporary file. %s.", e.getMessage()), e);
     }
-  }
-
-  /**
-   * Endpoint method to get the output schema of a query.
-   *
-   * @param request Config for the io.cdap.plugin.source.
-   * @param pluginContext context to create plugins
-   * @return output schema
-   */
-  @javax.ws.rs.Path("getSchema")
-  public Schema getSchema(T request, EndpointPluginContext pluginContext) {
-    return PathTrackingInputFormat.getOutputSchema(request.pathField);
   }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -81,8 +81,8 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <cdap.version>6.0.0-SNAPSHOT</cdap.version>
-    <cdap.plugin.version>2.2.0-SNAPSHOT</cdap.plugin.version>
+    <cdap.version>6.0.0</cdap.version>
+    <cdap.plugin.version>2.2.0</cdap.plugin.version>
     <widgets.dir>widgets</widgets.dir>
     <docs.dir>docs</docs.dir>
     <!-- properties for script build step that creates the config files for the artifacts -->


### PR DESCRIPTION
- Removes the usage of Endpoint as we have removed plugin functions in the platform
- Fixes widget json for ADLS batch source to properly show 3 groups 
- Updates CDAP version in pom to `6.1.0-SNAPSHOT`.

Verified in UI for individual groups + getSchema functionality.