### PR TITLE
 Azure keyvault store support needed in ADLS source/sink plugins to read ADLS credentials securely for production pipelines

### DIFF
--- a/adls-plugins/docs/ADLSBatchSink-batchsink.md
+++ b/adls-plugins/docs/ADLSBatchSink-batchsink.md
@@ -17,9 +17,9 @@ approach to avoid specifying sensitive Service Principle details in Plugin confi
 Please refer to `Notes on using KeyVault approach` below for more details.
 
 
-**keyVaultUrl** Provide Mircrosoft's KeyVault URL address from where client credentials can be fetched
+**Key Vault URL** Provide Mircrosoft's KeyVault URL address from where client credentials can be fetched
 
-**kvKeyNames** Provide key names for secret key-values to be fetched from KeyVault store. For connecting to ADLS as ClientCredentials role, a service
+**Key Vault Secret Key Names** Provide key names for secret key-values to be fetched from KeyVault store. For connecting to ADLS as ClientCredentials role, a service
 principle is required which gets specified by 3 configs - clientId, clientCrdential and RefreshTokenUrl. Therefore, each
 specified key name MUST be specified the identifier to which it should be mapped.
 

--- a/adls-plugins/docs/ADLSBatchSink-batchsink.md
+++ b/adls-plugins/docs/ADLSBatchSink-batchsink.md
@@ -14,10 +14,10 @@ Properties
 Either of configs {keyVaultUrl,kvKeyNames} OR {clientId,refreshTokenURL,credentials} MUST be specified.
 If former information is available, later configs are NOT required. Infact, former one(keyVault) is a more secured 
 approach to avoid specifying sensitive Service Principle details in Plugin config.
-Please refer to `DevNote` for using `keyVault` approach.
+Please refer to `Notes on using KeyVault approach` below for more details.
 
 
-**keyVaultUrl** Provide Mircroft's KeyVault URL address from where client credentials can be fetched
+**keyVaultUrl** Provide Mircrosoft's KeyVault URL address from where client credentials can be fetched
 
 **kvKeyNames** Provide key names for secret key-values to be fetched from KeyVault store. For connecting to ADLS as ClientCredentials role, a service
 principle is required which gets specified by 3 configs - clientId, clientCrdential and RefreshTokenUrl. Therefore, each
@@ -38,8 +38,9 @@ needed for the distributed file system. (Macro-enabled)
 
 **textDelimiter:** Delimiter to place between fields. Only used by the text output format. Defaults to tab.
 
-DevNote
--------
+
+Notes on using KeyVault Approach
+---------------------------------
 
 For using keyVault approach, plugin needs value of properties `fs.adl.oauth2.client.id` and `fs.adl.oauth2.credential`. One can specify these properties in plugin's config `fileSystemProperties`.
 

--- a/adls-plugins/docs/AzureDataLakeStore-batchsource.md
+++ b/adls-plugins/docs/AzureDataLakeStore-batchsource.md
@@ -18,9 +18,9 @@ approach to avoid specifying sensitive Service Principle details in Plugin confi
 Please refer to `Notes on using KeyVault approach` below for more details.
 
 
-**keyVaultUrl** Provide Mircrosoft's KeyVault URL address from where client credentials can be fetched
+**Key Vault URL** Provide Mircrosoft's KeyVault URL address from where client credentials can be fetched
 
-**kvKeyNames** Provide key names for secret key-values to be fetched from KeyVault store. For connecting to ADLS as ClientCredentials role, a service
+**Key Vault Secret Key Names** Provide key names for secret key-values to be fetched from KeyVault store. For connecting to ADLS as ClientCredentials role, a service
 principle is required which gets specified by 3 configs - clientId, clientCrdential and RefreshTokenUrl. Therefore, each
 specified key name MUST be specified the identifier to which it should be mapped.
 

--- a/adls-plugins/docs/AzureDataLakeStore-batchsource.md
+++ b/adls-plugins/docs/AzureDataLakeStore-batchsource.md
@@ -15,10 +15,10 @@ Properties
 Either of configs {keyVaultUrl,kvKeyNames} OR {clientId,refreshTokenURL,credentials} MUST be specified.
 If former information is available, later configs are NOT required. Infact, former one(keyVault) is a more secured 
 approach to avoid specifying sensitive Service Principle details in Plugin config.
-Please refer to `DevNote` for using `keyVault` approach.
+Please refer to `Notes on using KeyVault approach` below for more details.
 
 
-**keyVaultUrl** Provide Mircroft's KeyVault URL address from where client credentials can be fetched
+**keyVaultUrl** Provide Mircrosoft's KeyVault URL address from where client credentials can be fetched
 
 **kvKeyNames** Provide key names for secret key-values to be fetched from KeyVault store. For connecting to ADLS as ClientCredentials role, a service
 principle is required which gets specified by 3 configs - clientId, clientCrdential and RefreshTokenUrl. Therefore, each
@@ -62,8 +62,8 @@ URI will be used. Defaults to false.
 needed for the distributed file system. (Macro-enabled)
 
 
-DevNote
--------
+Notes on using KeyVault approach
+----------------------------------
 
 For using keyVault approach, plugin needs value of properties `fs.adl.oauth2.client.id` and `fs.adl.oauth2.credential`. One can specify these properties in plugin's config `fileSystemProperties`.
 

--- a/adls-plugins/docs/AzureDataLakeStore-batchsource.md
+++ b/adls-plugins/docs/AzureDataLakeStore-batchsource.md
@@ -64,9 +64,25 @@ needed for the distributed file system. (Macro-enabled)
 
 DevNote
 -------
-For using keyVault approach, it is required that underlying platform, on which CDAP is running, must contain a `/etc/security/jceks/adls.jceks`
-file which is generated using `hadoop-credential` utility. This `jceks` file is expected to contain values for following `keys` 
-so as to access `KeyVault` itself - `fs.adl.oauth2.client.id` and `fs.adl.oauth2.credential`.
+
+For using keyVault approach, plugin needs value of properties `fs.adl.oauth2.client.id` and `fs.adl.oauth2.credential`. One can specify these properties in plugin's config `fileSystemProperties`.
+
+However, even to read keyVault credentials securely, cluster admins can generate encrypted `adls.jceks` using hadoop credential utility containing these properties values as discussed here : https://hadoop.apache.org/docs/current/hadoop-project-dist/hadoop-common/CredentialProviderAPI.html
+
+The generated `adls.jceks` can be placed on all cluster nodes at some secured path (accessible only to cdap pipelines i.e. not exposed to user roles) by cluster admin. 
+
+The typical flow is :
+Plugin -- reads keyVault credentials from -------------------------------------------> `adls.jceks` file
+Plugin -- reads adls.jceks path from ------------------------------------------------> `core-site.xml`
+Plugin -- reads dfs.internal.nameservices (to insert in adls.jceks path) from -------> `hdfs-site.xml`
+Plugin -- reads ADLS credentials from -----------------------------------------------> `KeyVault store`
+Plugin -- accesses ------------------------------------------------------------------> `ADLS folders`
+
+(1) jceks path is expected to be a fully qualitfied path with identifier `hdfs` or `file` and with nameservice. Refer `https://hadoop.apache.org/docs/current/hadoop-project-dist/hadoop-common/CredentialProviderAPI.html`. 
+(2) Default `adls.jceks` path referred is `jceks://hdfs@mycluster/etc/security/jceks/adls.jceks`
+(3) if `core-site.xml` is provided, plugin tries to read jceks path from property `hadoop.security.credential.provider.path`
+(4) if `hdfs-site.xml` is provided, plugin tries to read nameservice from property `dfs.internal.nameservices` and update it in jceks path (if not already the case)
+(5) jceks file is expected to be present on all cluster nodes at path `/etc/security/jceks/adls.jceks`
 
 
 

--- a/adls-plugins/pom.xml
+++ b/adls-plugins/pom.xml
@@ -70,6 +70,26 @@
           </execution>
         </executions>
       </plugin>
+      <!--plugin>
+        <groupId>co.cask</groupId>
+        <artifactId>cdap-maven-plugin</artifactId>
+        <version>1.0.0</version>
+        <configuration>
+                <cdapArtifacts>
+                        <parent>system:cdap-data-streams[4.0.0,9.0.0)</parent>
+                        <parent>system:cdap-data-pipeline[4.0.0,9.0.0)</parent>
+                </cdapArtifacts>
+        </configuration>
+        <executions>
+                <execution>
+                        <id>create-artifact-config</id>
+                        <phase>prepare-package</phase>
+                        <goals>
+                                <goal>create-plugin-json</goal>
+                        </goals>
+                </execution>
+        </executions>
+      </plugin-->
     </plugins>
   </build>
 

--- a/adls-plugins/pom.xml
+++ b/adls-plugins/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <artifactId>azure-adls-plugins</artifactId>
     <groupId>io.cdap.plugin</groupId>
-    <version>1.6.0</version>
+    <version>1.7.0</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 
@@ -31,7 +31,7 @@
     <dependency>
       <groupId>io.cdap.plugin</groupId>
       <artifactId>filesource-common</artifactId>
-      <version>1.6.0</version>
+      <version>1.7.0</version>
     </dependency>
     <dependency>
       <groupId>org.apache.orc</groupId>
@@ -43,6 +43,11 @@
           <artifactId>hadoop-hdfs</artifactId>
         </exclusion>
       </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>io.netty</groupId>
+      <artifactId>netty-common</artifactId>
+      <version>4.1.16.Final</version>
     </dependency>
   </dependencies>
 

--- a/adls-plugins/pom.xml
+++ b/adls-plugins/pom.xml
@@ -31,12 +31,12 @@
     <dependency>
       <groupId>io.cdap.plugin</groupId>
       <artifactId>filesource-common</artifactId>
-      <version>1.7.0</version>
+      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.orc</groupId>
       <artifactId>orc-mapreduce</artifactId>
-      <version>1.1.0</version>
+      <version>${orc.mapreduce.version}</version>
       <exclusions>
         <exclusion>
           <groupId>org.apache.hadoop</groupId>
@@ -47,7 +47,7 @@
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-common</artifactId>
-      <version>4.1.16.Final</version>
+      <version>${netty.common.version}</version>
     </dependency>
   </dependencies>
 
@@ -75,26 +75,6 @@
           </execution>
         </executions>
       </plugin>
-      <!--plugin>
-        <groupId>co.cask</groupId>
-        <artifactId>cdap-maven-plugin</artifactId>
-        <version>1.0.0</version>
-        <configuration>
-                <cdapArtifacts>
-                        <parent>system:cdap-data-streams[4.0.0,9.0.0)</parent>
-                        <parent>system:cdap-data-pipeline[4.0.0,9.0.0)</parent>
-                </cdapArtifacts>
-        </configuration>
-        <executions>
-                <execution>
-                        <id>create-artifact-config</id>
-                        <phase>prepare-package</phase>
-                        <goals>
-                                <goal>create-plugin-json</goal>
-                        </goals>
-                </execution>
-        </executions>
-      </plugin-->
     </plugins>
   </build>
 

--- a/adls-plugins/src/main/java/io/cdap/plugin/sink/ADLSBatchSink.java
+++ b/adls-plugins/src/main/java/io/cdap/plugin/sink/ADLSBatchSink.java
@@ -29,6 +29,7 @@ import io.cdap.cdap.etl.api.PipelineConfigurer;
 import io.cdap.cdap.etl.api.batch.BatchRuntimeContext;
 import io.cdap.cdap.etl.api.batch.BatchSink;
 import io.cdap.cdap.etl.api.batch.BatchSinkContext;
+import io.cdap.plugin.common.azurecred.AzureClientSecretService;
 import io.cdap.plugin.common.HiveSchemaConverter;
 import io.cdap.plugin.common.ReferenceBatchSink;
 import io.cdap.plugin.common.ReferencePluginConfig;
@@ -45,7 +46,6 @@ import org.apache.hadoop.mapreduce.Job;
 import org.apache.hadoop.mapreduce.lib.output.FileOutputFormat;
 import org.apache.hadoop.mapreduce.lib.output.TextOutputFormat;
 import org.apache.orc.mapreduce.OrcOutputFormat;
-import io.cdap.plugin.common.azurecred.AzureClientSecretService;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -245,7 +245,7 @@ public class ADLSBatchSink extends ReferenceBatchSink<StructuredRecord, Object, 
       properties.put("fs.AbstractFileSystem.adl.impl", "org.apache.hadoop.fs.adl.Adl");
       properties.put("dfs.adls.oauth2.access.token.provider.type", "ClientCredential");
       if (keyVaultUrl != null && !keyVaultUrl.isEmpty()) {
-        Map<String, String> credentials = AzureClientSecretService.getADLSSecretsUsingJceksAndKV(keyVaultUrl, getKvKeyNamesMap(kvKeyNames));
+        Map<String, String> credentials = AzureClientSecretService.getADLSSecretsUsingJceksAndKV(keyVaultUrl, getKvKeyNamesMap(kvKeyNames), properties);
         properties.put("dfs.adls.oauth2.refresh.url", credentials.get("RefreshTokenUrl_KeyName"));
         properties.put("dfs.adls.oauth2.client.id", credentials.get("ClientId_KeyName"));
         properties.put("dfs.adls.oauth2.credential", credentials.get("ClientCredential_KeyName"));

--- a/adls-plugins/src/main/java/io/cdap/plugin/sink/ADLSBatchSink.java
+++ b/adls-plugins/src/main/java/io/cdap/plugin/sink/ADLSBatchSink.java
@@ -246,9 +246,9 @@ public class ADLSBatchSink extends ReferenceBatchSink<StructuredRecord, Object, 
       properties.put("dfs.adls.oauth2.access.token.provider.type", "ClientCredential");
       if (keyVaultUrl != null && !keyVaultUrl.isEmpty()) {
         Map<String, String> credentials = AzureClientSecretService.getADLSSecretsUsingJceksAndKV(keyVaultUrl, getKvKeyNamesMap(kvKeyNames), properties);
-        properties.put("dfs.adls.oauth2.refresh.url", credentials.get("RefreshTokenUrl_KeyName"));
-        properties.put("dfs.adls.oauth2.client.id", credentials.get("ClientId_KeyName"));
-        properties.put("dfs.adls.oauth2.credential", credentials.get("ClientCredential_KeyName"));
+        properties.put("dfs.adls.oauth2.refresh.url", credentials.get("Refresh Token Url Key-Name"));
+        properties.put("dfs.adls.oauth2.client.id", credentials.get("Client-Id Key-Name"));
+        properties.put("dfs.adls.oauth2.credential", credentials.get("Client Credential Key-Name"));
       } else {
         properties.put("dfs.adls.oauth2.refresh.url", refreshTokenURL);
         properties.put("dfs.adls.oauth2.client.id", clientId);

--- a/adls-plugins/src/main/java/io/cdap/plugin/source/ADLSBatchSource.java
+++ b/adls-plugins/src/main/java/io/cdap/plugin/source/ADLSBatchSource.java
@@ -115,6 +115,7 @@ public class ADLSBatchSource extends AbstractFileBatchSource {
       return properties;
     }
 
+    /* Cretae a map from KeyVault config */
     protected HashMap<String, String> getKvKeyNamesMap(String kvKeyNames) {
       HashMap<String, String> credMap = new HashMap<String, String>();
       String[] keypairs = kvKeyNames.split(",");

--- a/adls-plugins/src/main/java/io/cdap/plugin/source/ADLSBatchSource.java
+++ b/adls-plugins/src/main/java/io/cdap/plugin/source/ADLSBatchSource.java
@@ -104,9 +104,9 @@ public class ADLSBatchSource extends AbstractFileBatchSource {
 
       if (keyVaultUrl != null && !keyVaultUrl.isEmpty()) {
         Map<String, String> credentials = AzureClientSecretService.getADLSSecretsUsingJceksAndKV(keyVaultUrl, getKvKeyNamesMap(kvKeyNames), properties);
-        properties.put("dfs.adls.oauth2.refresh.url", credentials.get("RefreshTokenUrl_KeyName"));
-        properties.put("dfs.adls.oauth2.client.id", credentials.get("ClientId_KeyName"));
-        properties.put("dfs.adls.oauth2.credential", credentials.get("ClientCredential_KeyName"));
+        properties.put("dfs.adls.oauth2.refresh.url", credentials.get("Refresh Token Url Key-Name"));
+        properties.put("dfs.adls.oauth2.client.id", credentials.get("Client-Id Key-Name"));
+        properties.put("dfs.adls.oauth2.credential", credentials.get("Client Credential Key-Name"));
       } else {
         properties.put("dfs.adls.oauth2.refresh.url", refreshTokenURL);
         properties.put("dfs.adls.oauth2.client.id", clientId);

--- a/adls-plugins/src/main/java/io/cdap/plugin/source/ADLSBatchSource.java
+++ b/adls-plugins/src/main/java/io/cdap/plugin/source/ADLSBatchSource.java
@@ -21,9 +21,9 @@ import io.cdap.cdap.api.annotation.Macro;
 import io.cdap.cdap.api.annotation.Name;
 import io.cdap.cdap.api.annotation.Plugin;
 import io.cdap.cdap.etl.api.batch.BatchSource;
+import io.cdap.plugin.common.azurecred.AzureClientSecretService;
 import io.cdap.plugin.common.AbstractFileBatchSource;
 import io.cdap.plugin.common.FileSourceConfig;
-import io.cdap.plugin.common.azurecred.AzureClientSecretService;
 
 import javax.annotation.Nullable;
 import java.util.HashMap;
@@ -103,7 +103,7 @@ public class ADLSBatchSource extends AbstractFileBatchSource {
       properties.put("dfs.adls.oauth2.access.token.provider.type", "ClientCredential");
 
       if (keyVaultUrl != null && !keyVaultUrl.isEmpty()) {
-        Map<String, String> credentials = AzureClientSecretService.getADLSSecretsUsingJceksAndKV(keyVaultUrl, getKvKeyNamesMap(kvKeyNames));
+        Map<String, String> credentials = AzureClientSecretService.getADLSSecretsUsingJceksAndKV(keyVaultUrl, getKvKeyNamesMap(kvKeyNames), properties);
         properties.put("dfs.adls.oauth2.refresh.url", credentials.get("RefreshTokenUrl_KeyName"));
         properties.put("dfs.adls.oauth2.client.id", credentials.get("ClientId_KeyName"));
         properties.put("dfs.adls.oauth2.credential", credentials.get("ClientCredential_KeyName"));

--- a/adls-plugins/widgets/ADLSBatchSink-batchsink.json
+++ b/adls-plugins/widgets/ADLSBatchSink-batchsink.json
@@ -25,6 +25,21 @@
         },
         {
           "widget-type": "textbox",
+          "label": "Azure Key Vault URL",
+          "name": "keyVaultUrl"
+        },
+        {
+          "widget-type": "keyvalue-dropdown",
+          "label": "Azure KeyVault Secret Key Names",
+          "name": "kvKeyNames",
+          "widget-attributes": {
+              "delimiter": ",",
+              "kv-delimiter": ":",
+              "dropdownOptions": [ "ClientId_KeyName", "ClientCredential_KeyName","RefreshTokenUrl_KeyName"]
+          }
+        },
+        {
+          "widget-type": "textbox",
           "label": "Azure Data Lake Store Client Id",
           "name": "clientId"
         },

--- a/adls-plugins/widgets/ADLSBatchSink-batchsink.json
+++ b/adls-plugins/widgets/ADLSBatchSink-batchsink.json
@@ -35,7 +35,7 @@
           "widget-attributes": {
               "delimiter": ",",
               "kv-delimiter": ":",
-              "dropdownOptions": [ "ClientId_KeyName", "ClientCredential_KeyName","RefreshTokenUrl_KeyName"]
+              "dropdownOptions": [ "Client-Id Key-Name", "Client Credential Key-Name","Refresh Token Url Key-Name"]
           }
         },
         {

--- a/adls-plugins/widgets/AzureDataLakeStore-batchsource.json
+++ b/adls-plugins/widgets/AzureDataLakeStore-batchsource.json
@@ -25,6 +25,21 @@
         },
         {
           "widget-type": "textbox",
+          "label": "Azure Key Vault URL",
+          "name": "keyVaultUrl"
+        },
+        {
+          "widget-type": "keyvalue-dropdown",
+          "label": "Azure KeyVault Secret Key Names",
+          "name": "kvKeyNames",
+          "widget-attributes": {
+              "delimiter": ",",
+              "kv-delimiter": ":",
+              "dropdownOptions": [ "ClientId_KeyName", "ClientCredential_KeyName","RefreshTokenUrl_KeyName"]
+          }
+        },
+        {
+          "widget-type": "textbox",
           "label": "Azure Data Lake Store Client Id",
           "name": "clientId"
         },

--- a/adls-plugins/widgets/AzureDataLakeStore-batchsource.json
+++ b/adls-plugins/widgets/AzureDataLakeStore-batchsource.json
@@ -74,66 +74,60 @@
             ],
             "default": "false"
           }
+        }
+      ]
+    },
+    {
+      "label": "Output Schema Properties",
+      "properties": [
+        {
+          "widget-type": "textbox",
+          "label": "Path Field",
+          "name": "pathField"
         },
         {
-          "label": "Output Schema Properties",
-          "properties": [
-            {
-              "widget-type": "textbox",
-              "label": "Path Field",
-              "name": "pathField",
-              "plugin-function": {
-                "method": "POST",
-                "widget": "outputSchema",
-                "output-property": "schema",
-                "plugin-method": "getSchema"
-              }
-            },
-            {
-              "widget-type": "select",
-              "label": "Use File Name as Path Field",
-              "name": "filenameOnly",
-              "widget-attributes": {
-                "values": [
-                  "true",
-                  "false"
-                ],
-                "default": "false"
-              }
-            }
-          ]
+          "widget-type": "select",
+          "label": "Use File Name as Path Field",
+          "name": "filenameOnly",
+          "widget-attributes": {
+            "values": [
+              "true",
+              "false"
+            ],
+            "default": "false"
+          }
+        }
+      ]
+    },
+    {
+      "label": "Advanced Properties",
+      "properties": [
+        {
+          "widget-type": "textbox",
+          "label": "Input Format Class",
+          "name": "inputFormatClass"
         },
         {
-          "label": "Advanced Properties",
-          "properties": [
-            {
-              "widget-type": "textbox",
-              "label": "Input Format Class",
-              "name": "inputFormatClass"
-            },
-            {
-              "widget-type": "json-editor",
-              "label": "File System Properties",
-              "name": "fileSystemProperties"
-            },
-            {
-              "widget-type": "select",
-              "label": "Ignore Non-Existing Folders",
-              "name": "ignoreNonExistingFolders",
-              "widget-attributes": {
-                "values": [
-                  "true",
-                  "false"
-                ],
-                "default": "false"
-              }
-            },
-            {
-              "widget-type": "textbox",
-              "label": "Time Table",
-              "name": "timeTable"
-            }
-          ]
+          "widget-type": "json-editor",
+          "label": "File System Properties",
+          "name": "fileSystemProperties"
+        },
+        {
+          "widget-type": "select",
+          "label": "Ignore Non-Existing Folders",
+          "name": "ignoreNonExistingFolders",
+          "widget-attributes": {
+            "values": [
+              "true",
+              "false"
+            ],
+            "default": "false"
+          }
+        },
+        {
+          "widget-type": "textbox",
+          "label": "Time Table",
+          "name": "timeTable"
         }
       ]
     }

--- a/adls-plugins/widgets/AzureDataLakeStore-batchsource.json
+++ b/adls-plugins/widgets/AzureDataLakeStore-batchsource.json
@@ -35,7 +35,7 @@
           "widget-attributes": {
               "delimiter": ",",
               "kv-delimiter": ":",
-              "dropdownOptions": [ "ClientId_KeyName", "ClientCredential_KeyName","RefreshTokenUrl_KeyName"]
+              "dropdownOptions": [ "Client-Id Key-Name", "Client Credential Key-Name","Refresh Token Url Key-Name"]
           }
         },
         {

--- a/azure-blob-store/pom.xml
+++ b/azure-blob-store/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>azure-adls-plugins</artifactId>
     <groupId>io.cdap.plugin</groupId>
-    <version>1.6.0</version>
+    <version>1.7.0</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 
@@ -32,7 +32,7 @@
     <dependency>
       <groupId>io.cdap.plugin</groupId>
       <artifactId>filesource-common</artifactId>
-      <version>1.6.0</version>
+      <version>1.7.0</version>
     </dependency>
   </dependencies>
 

--- a/azure-blob-store/pom.xml
+++ b/azure-blob-store/pom.xml
@@ -60,6 +60,26 @@
           </execution>
         </executions>
       </plugin>
+      <!--plugin>
+        <groupId>co.cask</groupId>
+        <artifactId>cdap-maven-plugin</artifactId>
+        <version>1.0.0</version>
+        <configuration>
+                <cdapArtifacts>
+                        <parent>system:cdap-data-streams[4.0.0,9.0.0)</parent>
+                        <parent>system:cdap-data-pipeline[4.0.0,9.0.0)</parent>
+                </cdapArtifacts>
+        </configuration>
+        <executions>
+                <execution>
+                        <id>create-artifact-config</id>
+                        <phase>prepare-package</phase>
+                        <goals>
+                                <goal>create-plugin-json</goal>
+                        </goals>
+                </execution>
+        </executions>
+      </plugin-->
     </plugins>
   </build>
 

--- a/filesource-common/pom.xml
+++ b/filesource-common/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <artifactId>azure-adls-plugins</artifactId>
     <groupId>io.cdap.plugin</groupId>
-    <version>1.6.0</version>
+    <version>1.7.0</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/filesource-common/src/main/java/io/cdap/plugin/common/AbstractFileBatchSource.java
+++ b/filesource-common/src/main/java/io/cdap/plugin/common/AbstractFileBatchSource.java
@@ -23,7 +23,6 @@ import io.cdap.cdap.api.data.schema.Schema;
 import io.cdap.cdap.api.dataset.DatasetProperties;
 import io.cdap.cdap.api.dataset.lib.KeyValue;
 import io.cdap.cdap.api.dataset.lib.KeyValueTable;
-import io.cdap.cdap.api.plugin.EndpointPluginContext;
 import io.cdap.cdap.etl.api.Emitter;
 import io.cdap.cdap.etl.api.PipelineConfigurer;
 import io.cdap.cdap.etl.api.batch.BatchSourceContext;
@@ -213,11 +212,10 @@ public abstract class AbstractFileBatchSource<T extends FileSourceConfig>
    * Endpoint method to get the output schema of a query.
    *
    * @param request Config for the io.cdap.plugin.source.
-   * @param pluginContext context to create plugins
    * @return output schema
    */
   @javax.ws.rs.Path("getSchema")
-  public Schema getSchema(T request, EndpointPluginContext pluginContext) {
+  public Schema getSchema(T request) {  
     return PathTrackingInputFormat.getOutputSchema(request.pathField);
   }
 }

--- a/filesource-common/src/main/java/io/cdap/plugin/common/AbstractFileBatchSource.java
+++ b/filesource-common/src/main/java/io/cdap/plugin/common/AbstractFileBatchSource.java
@@ -207,15 +207,4 @@ public abstract class AbstractFileBatchSource<T extends FileSourceConfig>
       throw new IllegalArgumentException(String.format("Error deleting temporary file. %s.", e.getMessage()), e);
     }
   }
-
-  /**
-   * Endpoint method to get the output schema of a query.
-   *
-   * @param request Config for the io.cdap.plugin.source.
-   * @return output schema
-   */
-  @javax.ws.rs.Path("getSchema")
-  public Schema getSchema(T request) {  
-    return PathTrackingInputFormat.getOutputSchema(request.pathField);
-  }
 }

--- a/filesource-common/src/main/java/io/cdap/plugin/common/azurecred/AzureClientSecretService.java
+++ b/filesource-common/src/main/java/io/cdap/plugin/common/azurecred/AzureClientSecretService.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.plugin.common.azurecred;
+
+import com.microsoft.azure.keyvault.KeyVaultClient;
+import com.microsoft.azure.keyvault.authentication.KeyVaultCredentials;
+import com.microsoft.azure.keyvault.models.SecretBundle;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+//for jceks
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.security.alias.CredentialProvider;
+import org.apache.hadoop.security.alias.CredentialProviderFactory;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.ArrayList;
+import java.io.IOException;
+
+public class AzureClientSecretService {
+
+  private static Logger logger = LoggerFactory.getLogger(AzureClientSecretService.class);
+
+  public static HashMap<String, String> getADLSSecretsUsingJceksAndKV(String keyVaultUrl, HashMap<String, String> credMap) {
+    /* First get the credentials to access KeyVault from Jceks file */
+    HashMap<String, String> keymap = new HashMap<String, String>();
+    try {
+      keymap = getSecretsFromJcek("fs.adl.oauth2.client.id,fs.adl.oauth2.credential"); 
+      logger.info("KeyVault access identified");
+    } catch (Exception e) {
+      logger.error("jcek Exception : " + e);
+    }
+    return getSecretsFromKV(keyVaultUrl, credMap, keymap.get("fs.adl.oauth2.client.id"), keymap.get("fs.adl.oauth2.credential"));
+  }
+
+  public static HashMap<String, String> getSecretsFromKV(String vaultURI, HashMap<String, String> secretMap, String kvId, String kvSecret) {
+
+    /* Get keyVault client by providing authorized credentials as read from jceks */
+    KeyVaultClient client = new KeyVaultClient(new ClientSecretKeyVaultCredential(kvId, kvSecret));
+    
+    /* Now, Replace value in secretMap with actual value fetched from keyVault */
+    for (String key : secretMap.keySet()) {
+      SecretBundle secret = client.getSecret(vaultURI, secretMap.get(key));
+      secretMap.put(key,secret.value());
+    }
+    return secretMap;
+  }
+
+  public static HashMap<String, String> getSecretsFromJcek(String csvKeys) throws IOException {
+
+    HashMap<String, String> keyPasses = new HashMap<String, String>();
+    String[] keys = csvKeys.split(",");
+
+    /* Fetch password from configured credential provider path */
+    Configuration c = new Configuration();
+    /* TODO: jceks file location hardcoded for now, it is to be replaced by some other strategy like either reading from
+     * core-site.xml or cdap environment, etc. Till this story is defined, we keep it hard-coded
+     */
+    c.set(CredentialProviderFactory.CREDENTIAL_PROVIDER_PATH, "jceks://hdfs@mycluster/etc/security/jceks/adls.jceks");
+    CredentialProvider credentialProvider = CredentialProviderFactory.getProviders(c).get(0);
+    for(String key : keys) {
+      CredentialProvider.CredentialEntry entry = credentialProvider.getCredentialEntry(key);
+      if (entry == null) {
+        throw new IOException(String.format("No credential entry found for %s", key));
+      } else {
+        keyPasses.put(key, String.valueOf(entry.getCredential()));
+      }
+    }
+    return keyPasses;
+  }
+}
+

--- a/filesource-common/src/main/java/io/cdap/plugin/common/azurecred/AzureClientSecretService.java
+++ b/filesource-common/src/main/java/io/cdap/plugin/common/azurecred/AzureClientSecretService.java
@@ -69,7 +69,7 @@ public class AzureClientSecretService {
           Configuration conf = new Configuration();
           // Assumption: this path is always correct in Azure for hdfs-site.xml and core-site.xml
           Path coresite = new Path("file:///etc/hadoop/conf/hdfs-site.xml");
-          Path hdfssite = new Path("file:///etc/hadoop/conf/core-site.xml"));
+          Path hdfssite = new Path("file:///etc/hadoop/conf/core-site.xml");
           conf.addResource(coresite);
           conf.addResource(hdfssite);
           FileSystem fs = coresite.getFileSystem(conf);

--- a/filesource-common/src/main/java/io/cdap/plugin/common/azurecred/ClientSecretKeyVaultCredential.java
+++ b/filesource-common/src/main/java/io/cdap/plugin/common/azurecred/ClientSecretKeyVaultCredential.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.plugin.common.azurecred;
+
+import com.microsoft.aad.adal4j.AuthenticationContext;
+import com.microsoft.aad.adal4j.AuthenticationResult;
+import com.microsoft.aad.adal4j.ClientCredential;
+import com.microsoft.azure.keyvault.authentication.KeyVaultCredentials;
+
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+
+/**
+ * Refer Microsoft documentation:
+ * https://azure.github.io/azure-sdk-for-java/com/microsoft/azure/keyvault/authentication/KeyVaultCredentials.html
+ */
+public class ClientSecretKeyVaultCredential extends KeyVaultCredentials
+{
+    private String clientId;
+    private String clientKey;
+
+    public ClientSecretKeyVaultCredential( String clientId, String clientKey ) {
+        this.clientId = clientId;
+        this.clientKey = clientKey;
+    }
+
+    @Override
+    public String doAuthenticate(String authorization, String resource, String scope) {
+        AuthenticationResult token = getAccessTokenFromClientCredentials(
+                authorization, resource, clientId, clientKey);
+        return token.getAccessToken();
+    }
+
+    private static AuthenticationResult getAccessTokenFromClientCredentials(
+            String authorization, String resource, String clientId, String clientKey) {
+        AuthenticationContext context = null;
+        AuthenticationResult result = null;
+        ExecutorService service = null;
+        try {
+            service = Executors.newFixedThreadPool(1);
+            context = new AuthenticationContext(authorization, false, service);
+            ClientCredential credentials = new ClientCredential(clientId, clientKey);
+            Future<AuthenticationResult> future = context.acquireToken(
+                    resource, credentials, null);
+            result = future.get();
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        } finally {
+            service.shutdown();
+        }
+
+        if (result == null) {
+            throw new RuntimeException("authentication result was null");
+        }
+        return result;
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -81,8 +81,8 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <cdap.version>6.0.0-SNAPSHOT</cdap.version>
-    <cdap.plugin.version>2.2.0-SNAPSHOT</cdap.plugin.version>
+    <cdap.version>6.0.0</cdap.version>
+    <cdap.plugin.version>2.2.0</cdap.plugin.version>
     <netty.common.version>4.1.16.Final</netty.common.version>
     <orc.mapreduce.version>1.1.0</orc.mapreduce.version>
     <widgets.dir>widgets</widgets.dir>

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
   <artifactId>azure-adls-plugins</artifactId>
   <packaging>pom</packaging>
   <name>Azure Adls Plugin Collection</name>
-  <version>1.6.0</version>
+  <version>1.7.0</version>
 
   <licenses>
     <license>

--- a/pom.xml
+++ b/pom.xml
@@ -111,9 +111,30 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
+      <groupId>org.apache.hadoop</groupId>
+      <artifactId>hadoop-common</artifactId>
+      <version>2.7.3</version>
+      <exclusions>
+        <exclusion>
+          <groupId>com.google.guava</groupId>
+          <artifactId>guava</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
       <groupId>io.cdap.plugin</groupId>
       <artifactId>hydrator-common</artifactId>
       <version>${cdap.plugin.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>com.microsoft.azure</groupId>
+      <artifactId>azure</artifactId>
+      <version>1.3.0</version>
+    </dependency>
+    <dependency>
+      <groupId>com.microsoft.azure</groupId>
+      <artifactId>azure-keyvault</artifactId>
+      <version>1.0.0</version>
     </dependency>
   </dependencies>
 
@@ -128,6 +149,27 @@
             <source>1.7</source>
             <target>1.7</target>
           </configuration>
+        </plugin>
+        <plugin>
+          <groupId>net.alchim31.maven</groupId>
+          <artifactId>scala-maven-plugin</artifactId>
+          <executions>
+            <execution>
+              <id>scala-compile-first</id>
+              <phase>process-resources</phase>
+              <goals>
+                <goal>add-source</goal>
+                <goal>compile</goal>
+              </goals>
+            </execution>
+            <execution>
+              <id>scala-test-compile</id>
+              <phase>process-test-resources</phase>
+              <goals>
+                <goal>testCompile</goal>
+              </goals>
+            </execution>
+          </executions>
         </plugin>
         <plugin>
           <groupId>org.apache.felix</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -83,6 +83,8 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <cdap.version>6.0.0-SNAPSHOT</cdap.version>
     <cdap.plugin.version>2.2.0-SNAPSHOT</cdap.plugin.version>
+    <netty.common.version>4.1.16.Final</netty.common.version>
+    <orc.mapreduce.version>1.1.0</orc.mapreduce.version>
     <widgets.dir>widgets</widgets.dir>
     <docs.dir>docs</docs.dir>
     <!-- properties for script build step that creates the config files for the artifacts -->
@@ -149,27 +151,6 @@
             <source>1.7</source>
             <target>1.7</target>
           </configuration>
-        </plugin>
-        <plugin>
-          <groupId>net.alchim31.maven</groupId>
-          <artifactId>scala-maven-plugin</artifactId>
-          <executions>
-            <execution>
-              <id>scala-compile-first</id>
-              <phase>process-resources</phase>
-              <goals>
-                <goal>add-source</goal>
-                <goal>compile</goal>
-              </goals>
-            </execution>
-            <execution>
-              <id>scala-test-compile</id>
-              <phase>process-test-resources</phase>
-              <goals>
-                <goal>testCompile</goal>
-              </goals>
-            </execution>
-          </executions>
         </plugin>
         <plugin>
           <groupId>org.apache.felix</groupId>


### PR DESCRIPTION
Refer issue - https://issues.cask.co/browse/CDAP-15473 

Current ADLS source/sink plugins provides configuration options to connect to ADLS store. Here,
(1) user needs to provide this config in clear text which may be undesirable in production scenarios.  (2) Also, such credentials are visible in pipeline json when it needs to be pushed into Github like projects for versioning control, etc.

One has the option to use macros and get those values passed to pipeline at runtime through external processes.

However, one more alternate is to let the pipeline itself fetch credentials securely from Azure KeyVault store used for the project. Multiple pipelines running within same cluster mostly uses a common key-store configured for such purposes.

Therefore, one can specify keys stored in keyvault store to allow plugin automatically read required ADLS credentials from store and then access ADLS using the read credentials.

For using keyVault approach, plugin needs value of properties fs.adl.oauth2.client.id and fs.adl.oauth2.credential. One can specify these properties in plugin's config fileSystemProperties.

However, even to read keyVault credentials securely, cluster admins can generate encrypted adls.jceks using hadoop credential utility containing these properties values as discussed here : https://hadoop.apache.org/docs/current/hadoop-project-dist/hadoop-common/CredentialProviderAPI.html

The generated adls.jceks can be placed on all cluster nodes at some secured path (accessible only to cdap pipelines i.e. not exposed to user roles) by cluster admin.

The typical flow would be :
Plugin -- reads keyVault credentials from -------------------------------------------> adls.jceks file
Plugin -- reads adls.jceks path from (optional) --------------------------------------> core-site.xml
Plugin -- reads dfs.internal.nameservices (to insert in adls.jceks path) from (optional) -------> hdfs-site.xml
Plugin -- reads ADLS credentials from -----------------------------------------------> KeyVault store
Plugin -- accesses ------------------------------------------------------------------> ADLS folders

(1) jceks path is expected to be a fully qualiified path with identifier hdfs or file and with nameservice. Refer https://hadoop.apache.org/docs/current/hadoop-project-dist/hadoop-common/CredentialProviderAPI.html.
(2) Default adls.jceks path referred is jceks://hdfs@mycluster/etc/security/jceks/adls.jceks
(3) if core-site.xml is provided, plugin tries to read jceks path from property hadoop.security.credential.provider.path, else refers to default path
(4) if hdfs-site.xml is provided, plugin tries to read nameservice from property dfs.internal.nameservices and update it in jceks path (if not already the case); else uses the specified adls.jceks path as is and should be a valid one.
(5) jceks file is expected to be present on all cluster nodes at path /etc/security/jceks/adls.jceks

This way, the overall solution can be made usable in production pipelines where management of keys is left with a common key-vault store used by all cluster pipelines and no external process is required to pass on these keys to pipelines at run time.

This plugin enhancement is also usable by ADLS connection requirement in DataPrep service which is being tracked here : https://issues.cask.co/browse/CDAP-15248