### PR TITLE
Remove SNAPSHOT from plugins version.

### DIFF
--- a/adls-plugins/pom.xml
+++ b/adls-plugins/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <artifactId>azure-adls-plugins</artifactId>
     <groupId>io.cdap.plugin</groupId>
-    <version>1.7.0-SNAPSHOT</version>
+    <version>1.7.0</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 
@@ -31,7 +31,7 @@
     <dependency>
       <groupId>io.cdap.plugin</groupId>
       <artifactId>filesource-common</artifactId>
-      <version>1.7.0-SNAPSHOT</version>
+      <version>1.7.0</version>
     </dependency>
     <dependency>
       <groupId>org.apache.orc</groupId>

--- a/azure-blob-store/pom.xml
+++ b/azure-blob-store/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>azure-adls-plugins</artifactId>
     <groupId>io.cdap.plugin</groupId>
-    <version>1.7.0-SNAPSHOT</version>
+    <version>1.7.0</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 
@@ -32,7 +32,7 @@
     <dependency>
       <groupId>io.cdap.plugin</groupId>
       <artifactId>filesource-common</artifactId>
-      <version>1.7.0-SNAPSHOT</version>
+      <version>1.7.0</version>
     </dependency>
     <dependency>
       <groupId>org.apache.hadoop</groupId>

--- a/filesource-common/pom.xml
+++ b/filesource-common/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <artifactId>azure-adls-plugins</artifactId>
     <groupId>io.cdap.plugin</groupId>
-    <version>1.7.0-SNAPSHOT</version>
+    <version>1.7.0</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
   <artifactId>azure-adls-plugins</artifactId>
   <packaging>pom</packaging>
   <name>Azure Adls Plugin Collection</name>
-  <version>1.7.0-SNAPSHOT</version>
+  <version>1.7.0</version>
 
   <licenses>
     <license>


### PR DESCRIPTION
Update plugin version from 1.7.0-SNAPSHOT to 1.7.0;
MVN build succeeds. 