### PR TITLE
[CDAP-16927] Add validation for account name of Azure Blob Store.

### DIFF
--- a/azure-blob-store/docs/AzureBlobStore-batchsource.md
+++ b/azure-blob-store/docs/AzureBlobStore-batchsource.md
@@ -19,8 +19,8 @@ Properties
 **Path:** The path on Microsoft Azure Blob Storage to use as input. The path uses filename expansion (globbing) to read
 files. The path must start with `wasb://` or `wasbs://`, for example, `wasb://mycontainer@mystorageaccount.blob.core.windows.net/filename.txt`. (Macro-enabled)
 
-**Account:** The Microsoft Azure Blob Storage account to use. This is of the form 
-`mystorageaccount.blob.core.windows.net`, where `mystorageaccount` is the Microsoft 
+**Account:** The Microsoft Azure Blob Storage account to use. The account must end with `.blob.core.windows.net`. 
+For example, `mystorageaccount.blob.core.windows.net`, where `mystorageaccount` is the Microsoft 
 Azure Storage account name. (Macro-enabled)
 
 **Authentication Method:** The authentication method to use to connect to Microsoft Azure. Can be either 

--- a/azure-blob-store/src/main/java/io/cdap/plugin/source/AzureBatchSource.java
+++ b/azure-blob-store/src/main/java/io/cdap/plugin/source/AzureBatchSource.java
@@ -38,6 +38,7 @@ import javax.annotation.Nullable;
 @Description("Batch source to read from Azure Blob Storage.")
 public class AzureBatchSource extends AbstractFileBatchSource {
   private static final String PATH = "path";
+  private static final String ACCOUNT = "account";
   private static final String AUTHENTICATION_METHOD = "authenticationMethod";
   private static final String STORAGE_ACCOUNT_KEY = "storageKey";
   private static final String SAS_TOKEN = "sasToken";
@@ -90,9 +91,13 @@ public class AzureBatchSource extends AbstractFileBatchSource {
     @Override
     protected void validate(FailureCollector collector) {
       super.validate(collector);
-      if (!containsMacro("path") && (!path.startsWith("wasb://") && !path.startsWith("wasbs://"))) {
-        collector.addFailure("Path must start with wasb:// or wasbs:// for Windows Azure Storage Blob input files.", null)
+      if (!containsMacro(PATH) && (!path.startsWith("wasb://") && !path.startsWith("wasbs://"))) {
+        collector.addFailure("Path must start with wasb:// or wasbs:// for Windows Azure Blob Store input files.", null)
           .withConfigProperty(PATH);
+      }
+      if (!containsMacro(ACCOUNT) && !account.endsWith(".blob.core.windows.net")) {
+        collector.addFailure("Account must end with '.blob.core.windows.net' for Windows Azure Blob Store", null)
+          .withConfigProperty(ACCOUNT);
       }
       if (!(STORAGE_ACCOUNT_KEY_AUTH_METHOD.equalsIgnoreCase(authenticationMethod) ||
         SAS_TOKEN_AUTH_METHOD.equalsIgnoreCase(authenticationMethod))) {


### PR DESCRIPTION
Add validation for account name of Azure Blob Store, the account name must ends with ".blob.core.windows.net". Also, update the doc. 