### PR TITLE
Update pom.xml to use macro instead of fixed version

### DIFF
--- a/adls-plugins/pom.xml
+++ b/adls-plugins/pom.xml
@@ -31,7 +31,7 @@
     <dependency>
       <groupId>io.cdap.plugin</groupId>
       <artifactId>filesource-common</artifactId>
-      <version>1.8.0-SNAPSHOT</version>
+      <version>${project.parent.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.orc</groupId>

--- a/azure-blob-store/pom.xml
+++ b/azure-blob-store/pom.xml
@@ -32,7 +32,7 @@
     <dependency>
       <groupId>io.cdap.plugin</groupId>
       <artifactId>filesource-common</artifactId>
-      <version>1.8.0-SNAPSHOT</version>
+      <version>${project.parent.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.hadoop</groupId>


### PR DESCRIPTION
Projects in this repo depend on each other using fixed versions. This causes an issue when the project versions are bumped since the dependency versions also need to be bumped (see #68 ) to ensure the build succeeds. 

This PR uses a macro for the dependency version to ensure its always up to date