### PR TITLE
[CDAP-20238] Remove Spark2 references and update dependencies

### DIFF
--- a/adls-plugins/pom.xml
+++ b/adls-plugins/pom.xml
@@ -29,6 +29,17 @@
 
   <dependencies>
     <dependency>
+      <groupId>org.apache.avro</groupId>
+      <artifactId>avro-mapred</artifactId>
+      <version>1.7.7</version>
+    </dependency>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>4.13.1</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>io.cdap.plugin</groupId>
       <artifactId>filesource-common</artifactId>
       <version>${project.parent.version}</version>
@@ -56,7 +67,6 @@
       <plugin>
         <groupId>org.apache.felix</groupId>
         <artifactId>maven-bundle-plugin</artifactId>
-        <version>2.5.4</version>
         <extensions>true</extensions>
         <configuration>
           <instructions>

--- a/azure-blob-store/pom.xml
+++ b/azure-blob-store/pom.xml
@@ -46,7 +46,6 @@
       <plugin>
         <groupId>org.apache.felix</groupId>
         <artifactId>maven-bundle-plugin</artifactId>
-        <version>2.5.4</version>
         <extensions>true</extensions>
         <configuration>
           <instructions>

--- a/filesource-common/pom.xml
+++ b/filesource-common/pom.xml
@@ -33,7 +33,6 @@
       <plugin>
         <groupId>org.apache.felix</groupId>
         <artifactId>maven-bundle-plugin</artifactId>
-        <version>2.5.4</version>
         <extensions>true</extensions>
         <configuration>
           <instructions>

--- a/pom.xml
+++ b/pom.xml
@@ -91,6 +91,7 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <cdap.version>6.9.0-SNAPSHOT</cdap.version>
+    <hadoop.version>2.10.2</hadoop.version>
     <cdap.plugin.version>2.6.0</cdap.plugin.version>
     <widgets.dir>widgets</widgets.dir>
     <docs.dir>docs</docs.dir>
@@ -101,6 +102,11 @@
   </properties>
 
   <dependencies>
+    <dependency>
+      <groupId>org.apache.hadoop</groupId>
+      <artifactId>hadoop-client</artifactId>
+      <version>${hadoop.version}</version>
+    </dependency>
     <dependency>
       <groupId>io.cdap.cdap</groupId>
       <artifactId>cdap-etl-api</artifactId>
@@ -115,7 +121,7 @@
     </dependency>
     <dependency>
       <groupId>io.cdap.cdap</groupId>
-      <artifactId>cdap-data-pipeline2_2.11</artifactId>
+      <artifactId>cdap-data-pipeline3_2.12</artifactId>
       <version>${cdap.version}</version>
       <scope>provided</scope>
     </dependency>
@@ -141,7 +147,7 @@
         <plugin>
           <groupId>org.apache.felix</groupId>
           <artifactId>maven-bundle-plugin</artifactId>
-          <version>2.5.4</version>
+          <version>3.5.0</version>
           <extensions>true</extensions>
           <configuration>
             <instructions>


### PR DESCRIPTION
As part of cdapio/cdap/pull/14797, the spark2 modules and references have been removed. Similar references in this repo need to be done and subsequent dependencies need to be updated.