### PR TITLE
[CDAP-21027] Upgrade hadoop to 3.3.6

### DIFF
--- a/adls-plugins/pom.xml
+++ b/adls-plugins/pom.xml
@@ -31,7 +31,7 @@
     <dependency>
       <groupId>org.apache.avro</groupId>
       <artifactId>avro-mapred</artifactId>
-      <version>1.7.7</version>
+      <version>1.11.4</version>
     </dependency>
     <dependency>
       <groupId>junit</groupId>
@@ -58,7 +58,7 @@
     <dependency>
       <groupId>org.apache.hadoop</groupId>
       <artifactId>hadoop-azure-datalake</artifactId>
-      <version>2.9.2</version>
+      <version>${hadoop.version}</version>
     </dependency>
   </dependencies>
 

--- a/azure-blob-store/pom.xml
+++ b/azure-blob-store/pom.xml
@@ -37,7 +37,7 @@
     <dependency>
       <groupId>org.apache.hadoop</groupId>
       <artifactId>hadoop-azure</artifactId>
-      <version>2.8.0</version>
+      <version>${hadoop.version}</version>
     </dependency>
   </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -79,24 +79,37 @@
 
   <repositories>
     <repository>
-      <id>sonatype.release</id>
-      <url>https://oss.sonatype.org/service/local/staging/deploy/maven2</url>
+      <id>sonatype</id>
+      <url>https://oss.sonatype.org/content/groups/public</url>
+      <releases>
+        <enabled>true</enabled>
+      </releases>
+      <snapshots>
+        <enabled>false</enabled>
+      </snapshots>
     </repository>
     <repository>
       <id>sonatype-snapshots</id>
       <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+      <releases>
+        <enabled>false</enabled>
+      </releases>
+      <snapshots>
+        <enabled>true</enabled>
+      </snapshots>
     </repository>
   </repositories>
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <cdap.version>6.9.0</cdap.version>
-    <hadoop.version>2.10.2</hadoop.version>
-    <cdap.plugin.version>2.6.0</cdap.plugin.version>
+    <cdap.version>6.11.0-SNAPSHOT</cdap.version>
+    <hadoop.version>3.3.6</hadoop.version>
+    <cdap.plugin.version>2.13.0-SNAPSHOT</cdap.plugin.version>
     <widgets.dir>widgets</widgets.dir>
     <docs.dir>docs</docs.dir>
     <!-- properties for script build step that creates the config files for the artifacts -->
-    <app.parents>system:cdap-data-pipeline[6.1.0-SNAPSHOT,7.0.0-SNAPSHOT),system:cdap-data-streams[6.1.0-SNAPSHOT,7.0.0-SNAPSHOT)
+    <app.parents>
+      system:cdap-data-pipeline[6.11.0-SNAPSHOT,7.0.0-SNAPSHOT),system:cdap-data-streams[6.11.0-SNAPSHOT,7.0.0-SNAPSHOT)
     </app.parents>
     <main.basedir>${project.basedir}</main.basedir>
   </properties>


### PR DESCRIPTION
```
Step #4 - "build-cdap": [ERROR] Failed to execute goal on project azure-adls-plugins: Could not resolve dependencies for project io.cdap.plugin:azure-adls-plugins:pom:1.18.0-SNAPSHOT: Failed to collect dependencies at org.apache.hadoop:hadoop-client:jar:2.10.2 -> org.apache.hadoop:hadoop-common:jar:2.10.2 -> org.apache.hadoop:hadoop-auth:jar:2.10.2 -> com.nimbusds:nimbus-jose-jwt:jar:7.9 -> net.minidev:json-smart:jar:[1.3.1,2.3]: No versions available for net.minidev:json-smart:jar:[1.3.1,2.3] within specified range -> [Help 1]
```